### PR TITLE
Removing unnecessary dependencies and Travis notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - "4.3.2"
 before_script: npm install -g zapier-platform-cli
 script: zapier test
+notifications:
+  email: false

--- a/package.json
+++ b/package.json
@@ -16,14 +16,11 @@
   },
   "dependencies": {
     "form-data": "2.1.4",
-    "lodash": "4.15.0",
     "request": "2.81.0",
     "zapier-platform-core": "1.0.9"
   },
   "devDependencies": {
-    "babel": "6.5.2",
-    "babel-eslint": "6.1.2",
     "mocha": "2.5.3",
-    "should": "9.0.2"
+    "should": "11.2.1"
   }
 }


### PR DESCRIPTION
The tests will fail with that `length` error until this gets an upgrade to `zapier-platform-core: 1.0.10`, which isn't available yet.