### PR TITLE
Add a skip to a test that requires the ZAPIER DEPLOY KEY env

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "zapier-platform-core": "3.2.1"
   },
   "devDependencies": {
-    "mocha": "2.5.3",
+    "mocha": "3.5.3",
     "should": "11.2.1"
   }
 }

--- a/test/hydrators.js
+++ b/test/hydrators.js
@@ -7,6 +7,10 @@ describe('hydrators', () => {
 
   describe('uploadFile', () => {
     it('should download files', (done) => {
+      if (!process.env || !process.env.ZAPIER_DEPLOY_KEY) {
+        this.skip();
+      }
+
       const bundle = {
         inputData: {
           fileId: 3,


### PR DESCRIPTION
When devs fork and try to run the Travis tests, this one fails because Travis (rightfully) does not include the `ZAPIER_DEPLOY_KEY` env variable.